### PR TITLE
fixed: use non blocking channel in HTTPCollector.Collect()

### DIFF
--- a/collector-http_test.go
+++ b/collector-http_test.go
@@ -42,6 +42,11 @@ func TestHttpCollector(t *testing.T) {
 	if err := c.Collect(span); err != nil {
 		t.Errorf("error during collection: %v", err)
 	}
+
+	// Collection is now using a buffered channel which is non blocking
+	// so we need to wait a tiny bit.
+	<-time.After(300 * time.Millisecond)
+
 	if err := c.Close(); err != nil {
 		t.Fatalf("error during collection: %v", err)
 	}


### PR DESCRIPTION
This patch makes the span collection channel buffered, and the Collect() method
to use a non blocking send. The buffer size of the channel is equal
to the backlog size. It also removes the actual async HTTP post.

Previously, when the application was under heavy load, the number of send() go routines
was skyrocketing, reaching the -race goroutine limit of 8192 in less than a 10sec.

I see that the scribe collector is using the same system, I would be happy to convert it too
if this patch gets accepted.