### PR TITLE
Avoid deadlocking when Collector Closed concurrently with Collect call

### DIFF
--- a/collector-http.go
+++ b/collector-http.go
@@ -118,7 +118,12 @@ func NewHTTPCollector(url string, options ...HTTPOption) (Collector, error) {
 
 // Collect implements Collector.
 func (c *HTTPCollector) Collect(s *zipkincore.Span) error {
-	c.spanc <- s
+	select {
+	case c.spanc <- s:
+		// Accepted.
+	case <-c.quit:
+		// Collector concurrently closed.
+	}
 	return nil
 }
 

--- a/collector-scribe.go
+++ b/collector-scribe.go
@@ -113,8 +113,13 @@ func NewScribeCollector(addr string, timeout time.Duration, options ...ScribeOpt
 
 // Collect implements Collector.
 func (c *ScribeCollector) Collect(s *zipkincore.Span) error {
-	c.spanc <- s
-	return nil // accepted
+	select {
+	case c.spanc <- s:
+		// Accepted.
+	case <-c.quit:
+		// Collector concurrently closed.
+	}
+	return nil
 }
 
 // Close implements Collector.


### PR DESCRIPTION
When a Collector is closed while other goroutines are attempting to
record spans, it shouldn't deadlock.