### PR TITLE
Make aggregateErrors return nil when no errors in multi collect

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -47,6 +47,11 @@ func (c MultiCollector) aggregateErrors(f func(c Collector) error) error {
 			e.errs[i] = err
 		}
 	}
+
+	if e == nil {
+		return nil
+	}
+
 	return e
 }
 

--- a/collector_test.go
+++ b/collector_test.go
@@ -76,6 +76,24 @@ func TestMultiCollector(t *testing.T) {
 	}
 }
 
+func TestMultiCollectorNoError(t *testing.T) {
+	cs := MultiCollector{
+		&stubCollector{},
+		&stubCollector{},
+		&stubCollector{},
+	}
+	err := cs.Collect(s)
+	if err != nil {
+		t.Fatal("wanted no error, got error")
+	}
+
+	for _, c := range cs {
+		if !c.(*stubCollector).collected {
+			t.Error("collect not called")
+		}
+	}
+}
+
 func TestMultiCollectorClose(t *testing.T) {
 	cs := MultiCollector{
 		&stubCollector{errid: 1},


### PR DESCRIPTION
Currently, if no `Collect()` call returns an error in the `MultiCollector` implementation, `aggregateError` will return a `nil` `collectionError` that will not be correctly comparable to `nil` from the caller.

This PR should fix issue https://github.com/openzipkin-contrib/zipkin-go-opentracing/issues/115.