### PR TITLE
Fix bugs in textMapPropagator.Extract

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: go
 
 go:
-  - 1.8
-  - 1.9
-  - tip
+  - "1.9"
+  - "1.10"
+  - "tip"
 
 install:
   - go get -d -t ./...
-  - go get -u github.com/golang/lint/...
+  - go get -u golang.org/x/lint/...
 script:
   - make test vet lint bench


### PR DESCRIPTION
* Fail if a required field (TraceID or SpanID) is not set
* Support carriers that only specify TraceID and SpanID

Fixes #118