### PR TITLE
chore(zipkin): adds sampler type to ease migration.

### DIFF
--- a/sample.go
+++ b/sample.go
@@ -1,0 +1,5 @@
+package zipkintracer
+
+// Sampler functions return if a Zipkin span should be sampled, based on its
+// traceID.
+type Sampler func(id uint64) bool

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -70,9 +70,9 @@ func WithLocalEndpoint(e Endpoint) TracerOption {
 }
 
 // WithSampler allows one to add a Sampler function
-func WithSampler(sampler func(traceID uint64) bool) TracerOption {
+func WithSampler(sampler Sampler) TracerOption {
 	return func(opts *TracerOptions) error {
-		opts.sampler = sampler
+		opts.sampler = zipkin.Sampler(sampler)
 		return nil
 	}
 }


### PR DESCRIPTION
While migrating one service from the old to the new service I found that the `Sampler` type was missing so I am adding here.

Ping @stakhiv @basvanbeek 