### PR TITLE
fixes broken parent context import due to signature change of SpanContext

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -46,9 +46,9 @@ func (t *tracerImpl) StartSpan(operationName string, opts ...opentracing.StartSp
 
 	// Parent
 	if len(startSpanOptions.References) > 0 {
-		parent, ok := (startSpanOptions.References[0].ReferencedContext).(*SpanContext)
+		parent, ok := (startSpanOptions.References[0].ReferencedContext).(SpanContext)
 		if ok {
-			zopts = append(zopts, zipkin.Parent(model.SpanContext(*parent)))
+			zopts = append(zopts, zipkin.Parent(model.SpanContext(parent)))
 		}
 	}
 


### PR DESCRIPTION
Whoopsie... we changed the SpanContext signature and it wasn't picked up anymore from the internal StartSpan function.

We'll need to add a test case for this so we won't regress in the future.