### PR TITLE
Improve handling of span.kind OT tag

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -82,8 +82,16 @@ func parseTagsAsZipkinOptions(t map[string]interface{}) []zipkin.SpanOption {
 	tags := map[string]string{}
 	remoteEndpoint := &model.Endpoint{}
 
+	var kind string
 	if val, ok := t[string(ext.SpanKind)]; ok {
-		kind, _ := val.(string)
+		switch kindVal := val.(type) {
+		case ext.SpanKindEnum:
+			kind = string(kindVal)
+		case string:
+			kind = kindVal
+		default:
+			kind = fmt.Sprintf("%v", kindVal)
+		}
 		zopts = append(zopts, zipkin.Kind(model.Kind(strings.ToUpper(kind))))
 	}
 


### PR DESCRIPTION
span.kind OT tag sometimes is sent as string but if using ext package it will be ext.SpanKindEnum.

This allows for both types to be handled properly.