### PR TITLE
fix(propagation): fixes propagation for opentracing.TextMap.

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -110,7 +110,8 @@ func (p *textMapPropagator) Extract(
 		m := make(b3.Map)
 		carrier.ForeachKey(func(key string, val string) error {
 			// no matter the format of the B3 headers, they will be retrieved
-			// using the standard lowercase format e.g. x-b3-traceid
+			// using the standard lowercase format e.g. x-b3-traceid. See
+			// https://github.com/openzipkin/zipkin-go/blob/master/propagation/b3/shared.go
 			m[strings.ToLower(key)] = val
 			return nil
 		})

--- a/propagation.go
+++ b/propagation.go
@@ -16,6 +16,7 @@ package zipkintracer
 
 import (
 	"net/http"
+	"strings"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/openzipkin/zipkin-go/model"
@@ -108,7 +109,9 @@ func (p *textMapPropagator) Extract(
 	if carrier, ok := opaqueCarrier.(opentracing.TextMapReader); ok {
 		m := make(b3.Map)
 		carrier.ForeachKey(func(key string, val string) error {
-			m[key] = val
+			// no matter the format of the B3 headers, they will be retrieved
+			// using the standard lowercase format e.g. x-b3-traceid
+			m[strings.ToLower(key)] = val
 			return nil
 		})
 		sc, err := m.Extract()


### PR DESCRIPTION
Currently, when trying to extract the context from a carrier that implements `opentracing.TextMap`, the extraction fails if the carrier contains headers in the non-standard way, e.g. http headers like `X-B3-Traceid`. This does not happen if one use the `opentracing.HTTPHeadersCarrier` but if one uses a custom carrier like [traefik does](https://github.com/containous/traefik/blob/master/pkg/tracing/carrier.go#L7).

Whether we `traefik` should use its own carrier or use the `OT` one, in our side it makes sense that we standarize `http headers` because then we aim to retrieve them using lower cases: see https://github.com/openzipkin/zipkin-go/blob/master/propagation/b3/shared.go

Related to https://github.com/containous/traefik/issues/5511

Ping @basvanbeek @trajano